### PR TITLE
ダークモード非対応設定

### DIFF
--- a/keepYourFaceGreat/Info.plist
+++ b/keepYourFaceGreat/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>User Interface Style</key>
+	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
# clone コマンド
git clone -b feature/setDarkMode https://github.com/yu20201227/KeepYourFaceGreat.git

## Trello
ダークモード非対応実装

## 概要
info.plistでダークモード非対応実装

## 11 Pro や SEなど異なる端末でもレイアウトが崩れないか？
別チケット

## レビュー依頼
※[WIP]の場合は全て消して依頼しないようにしてください
@fuchi0741 

レビューお願いしますー！

## 補足